### PR TITLE
SetLine/Marker/FillColorAlpha added to root_attr.i and GetStdDev added to root_hist.i

### DIFF
--- a/ruby/root_attributes.i
+++ b/ruby/root_attributes.i
@@ -17,6 +17,7 @@ public:
   virtual void     SaveLineAttributes(ostream &out, const char *name, Int_t coldef=1, Int_t stydef=1, Int_t widdef=1);
   virtual void     SetLineAttributes(); // *MENU*
   virtual void     SetLineColor(Color_t lcolor);
+  virtual void  SetLineColorAlpha (Color_t lcolor, Float_t lalpha);
   virtual void     SetLineStyle(Style_t lstyle);
   virtual void     SetLineWidth(Width_t lwidth);
 };
@@ -37,6 +38,7 @@ public:
   virtual void     SaveFillAttributes(ostream &out, const char *name, Int_t coldef=1, Int_t stydef=1001);
   virtual void     SetFillAttributes(); // *MENU*
   virtual void     SetFillColor(Color_t fcolor);
+  virtual void  SetFillColorAlpha (Color_t fcolor, Float_t falpha);
   virtual void     SetFillStyle(Style_t fstyle);
 };
 
@@ -56,6 +58,7 @@ public:
   virtual void     SaveMarkerAttributes(ostream &out, const char *name, Int_t coldef=1, Int_t stydef=1, Int_t sizdef=1);
   virtual void     SetMarkerAttributes();  // *MENU*
   virtual void     SetMarkerColor(Color_t tcolor=1);
+  virtual void  SetMarkerColorAlpha (Color_t mcolor, Float_t malpha);
   virtual void     SetMarkerStyle(Style_t mstyle=1);
   virtual void     SetMarkerSize(Size_t msize=1);
 };

--- a/ruby/root_hist.i
+++ b/ruby/root_hist.i
@@ -133,6 +133,7 @@ public:
   virtual const TArrayD *GetSumw2() const;
   virtual Int_t    GetSumw2N() const;
   virtual Double_t GetRMS(Int_t axis=1) const;
+  virtual Double_t 	GetStdDev (Int_t axis=1) const;
   virtual Double_t GetRMSError(Int_t axis=1) const;
   virtual Double_t GetSkewness(Int_t axis=1) const;
   TAxis   *GetXaxis() const;


### PR DESCRIPTION
- SetLine/Marker/FillColorAlpha added to root_attr.i to use transparent colors in plots.
- GetStdDev (see https://twitter.com/AkiraOkumura/status/273056601747910657)