### PR TITLE
PR: Make color palette movable

### DIFF
--- a/examples/color_palette.rb
+++ b/examples/color_palette.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+require 'RubyROOT'
+include RootApp
+
+Root::gStyle.SetOptStat(0)
+
+Root::gStyle.set_palette 'cool'
+c1 = Root::TCanvas.create_square()
+n = 64
+size = 20.0
+hsize = 0.5*size
+h = Root::TH2F.create('image', 'Image', n, -hsize, +hsize, n, -hsize, +hsize)
+
+random = Root::TRandom3.new
+radii = [4.0, 8.0, 12.0]
+radii.each do |radius|
+  60000.times do |i|
+    theta = random.Uniform(0.0, 2.0*Math::PI)
+    r = random.Gaus(radius, 1.0)
+    x = r * Math::cos(theta)
+    y = r * Math::sin(theta)
+    h.Fill(x, y)
+  end
+end
+
+h.Draw 'colz'
+c1.Update
+
+# Move color palette
+palette = Root::gPad.get_palette()
+palette.SetX1NDC(0.5)
+palette.SetY1NDC(0.5)
+h.Draw 'colz'
+c1.Update
+
+run_app

--- a/ruby/RubyROOT.rb
+++ b/ruby/RubyROOT.rb
@@ -561,6 +561,12 @@ module Root
     end
   end
 
+  class TVirtualPad
+    def get_palette()
+      self.GetPrimitive("palette").auto_cast
+    end
+  end
+
   class TCanvas
     def self.create_square(size=600, name='c1', title='c1')
       wx = size+4

--- a/ruby/root.i
+++ b/ruby/root.i
@@ -17,6 +17,7 @@
 #include <TObjArray.h>
 #include <TMap.h>
 #include <TAxis.h>
+#include <TPaletteAxis.h>
 #include <TApplication.h>
 #include <TRint.h>
 #include <TH1.h>
@@ -83,13 +84,14 @@
 %include "root_math.i"
 %include "root_list.i"
 %include "root_attributes.i"
+%include "root_graf.i"
+%include "root_pave.i"
 %include "root_axis.i"
 %include "root_app.i"
 %include "root_hist.i"
 %include "root_hist2d.i"
 %include "root_hist3d.i"
 %include "root_tree.i"
-%include "root_graf.i"
 %include "root_graph.i"
 %include "root_func.i"
 %include "root_file.i"

--- a/ruby/root_axis.i
+++ b/ruby/root_axis.i
@@ -87,3 +87,35 @@ public:
   virtual void       UnZoom();  // *MENU*
   virtual void       ZoomOut(Double_t factor=0, Double_t offset=0);  // *MENU*
 };
+
+class TPaletteAxis : public TPave {
+public:
+   TPaletteAxis();
+   TPaletteAxis(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2, TH1 *h);
+   TPaletteAxis(const TPaletteAxis &palette);
+   virtual ~TPaletteAxis();
+   void Copy(TObject &palette) const;
+   TPaletteAxis& operator=(const TPaletteAxis&);
+
+   virtual Int_t DistancetoPrimitive(Int_t px, Int_t py);
+   virtual void  ExecuteEvent(Int_t event, Int_t px, Int_t py);
+   TGaxis       *GetAxis() {return &fAxis;}
+   Int_t         GetBinColor(Int_t i, Int_t j);
+   TH1*          GetHistogram(){return fH;}
+   Option_t     *GetName() const {return fName.Data();}
+   virtual char *GetObjectInfo(Int_t px, Int_t py) const;
+   Int_t         GetValueColor(Double_t zc);
+   virtual void  Paint(Option_t *option="");
+   virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
+   void          SetHistogram(TH1* h) {fH = h;}
+   virtual void  SetName(const char *name="") {fName = name;} // *MENU*
+   virtual void  SetLabelColor(Int_t labelcolor) {fAxis.SetLabelColor(labelcolor);} // *MENU*
+   virtual void  SetLabelFont(Int_t labelfont) {fAxis.SetLabelFont(labelfont);} // *MENU*
+   virtual void  SetLabelOffset(Float_t labeloffset) {fAxis.SetLabelOffset(labeloffset);} // *MENU*
+   virtual void  SetLabelSize(Float_t labelsize) {fAxis.SetLabelSize(labelsize);} // *MENU*
+   virtual void  SetTitleOffset(Float_t titleoffset=1) {fAxis.SetTitleOffset(titleoffset);} // *MENU*
+   virtual void  SetTitleSize(Float_t titlesize) {fAxis.SetTitleSize(titlesize);} // *MENU*
+   virtual void  SetLineColor(Color_t linecolor) {fAxis.SetLineColor(linecolor);} // *MENU*
+   virtual void  SetLineWidth(Width_t linewidth) {fAxis.SetLineWidth(linewidth);} // *MENU*
+   virtual void  UnZoom();  // *MENU*
+};

--- a/ruby/root_cast.i
+++ b/ruby/root_cast.i
@@ -51,3 +51,4 @@
 %template(castIntoTSpline) castInto<TSpline>;
 %template(castIntoTSpline3) castInto<TSpline3>;
 %template(castIntoTSpline5) castInto<TSpline5>;
+%template(castIntoTPaletteAxis) castInto<TPaletteAxis>;

--- a/ruby/root_legend.i
+++ b/ruby/root_legend.i
@@ -2,55 +2,6 @@
 /* Legend classes                                                         */
 /**************************************************************************/
 
-class TPave : public TBox {
-public:
-  TPave();
-  TPave(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
-        Int_t bordersize=4 ,Option_t *option="br");
-  TPave(const TPave &pave);
-  virtual ~TPave();
-  void  Copy(TObject &pave) const;
-  virtual void  ConvertNDCtoPad();
-  virtual Int_t DistancetoPrimitive(Int_t px, Int_t py);
-  virtual void  Draw(Option_t *option="");
-  virtual void  DrawPave(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
-                         Int_t bordersize=4 ,Option_t *option="br");
-  virtual void  ExecuteEvent(Int_t event, Int_t px, Int_t py);
-  Int_t       GetBorderSize() const;
-  Double_t    GetCornerRadius() const;
-  Option_t   *GetName() const;
-  Option_t   *GetOption() const;
-  Int_t       GetShadowColor() const;
-  Double_t    GetX1NDC() const;
-  Double_t    GetX2NDC() const;
-  Double_t    GetY1NDC() const;
-  Double_t    GetY2NDC() const;
-  virtual ULong_t  Hash() const;
-  virtual Bool_t   IsSortable() const;
-  virtual void  ls(Option_t *option="") const;
-  virtual void  Paint(Option_t *option="");
-  virtual void  PaintPave(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
-                          Int_t bordersize=4 ,Option_t *option="br");
-  virtual void  PaintPaveArc(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
-                             Int_t bordersize=4 ,Option_t *option="br");
-  virtual void  Print(Option_t *option="") const;
-  virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
-  virtual void  SetBorderSize(Int_t bordersize=4);
-  virtual void  SetCornerRadius(Double_t rad = 0.2);
-  virtual void  SetName(const char *name="");
-  virtual void  SetOption(Option_t *option="br");
-  virtual void  SetShadowColor(Int_t color);
-  virtual void  SetX1NDC(Double_t x1);
-  virtual void  SetX2NDC(Double_t x2);
-  virtual void  SetY1NDC(Double_t y1);
-  virtual void  SetY2NDC(Double_t y2);
-  virtual void  SetX1(Double_t x1);
-  virtual void  SetX2(Double_t x2);
-  virtual void  SetY1(Double_t y1);
-  virtual void  SetY2(Double_t y2);
-};
-
-
 class TLegendEntry : public TObject, public TAttText, public TAttLine,
                      public TAttFill, public TAttMarker {
 public:

--- a/ruby/root_pave.i
+++ b/ruby/root_pave.i
@@ -1,0 +1,51 @@
+/**************************************************************************/
+/* Pave classes                                                           */
+/**************************************************************************/
+
+class TPave : public TBox {
+public:
+  TPave();
+  TPave(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
+        Int_t bordersize=4 ,Option_t *option="br");
+  TPave(const TPave &pave);
+  virtual ~TPave();
+  void  Copy(TObject &pave) const;
+  virtual void  ConvertNDCtoPad();
+  virtual Int_t DistancetoPrimitive(Int_t px, Int_t py);
+  virtual void  Draw(Option_t *option="");
+  virtual void  DrawPave(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
+                         Int_t bordersize=4 ,Option_t *option="br");
+  virtual void  ExecuteEvent(Int_t event, Int_t px, Int_t py);
+  Int_t       GetBorderSize() const;
+  Double_t    GetCornerRadius() const;
+  Option_t   *GetName() const;
+  Option_t   *GetOption() const;
+  Int_t       GetShadowColor() const;
+  Double_t    GetX1NDC() const;
+  Double_t    GetX2NDC() const;
+  Double_t    GetY1NDC() const;
+  Double_t    GetY2NDC() const;
+  virtual ULong_t  Hash() const;
+  virtual Bool_t   IsSortable() const;
+  virtual void  ls(Option_t *option="") const;
+  virtual void  Paint(Option_t *option="");
+  virtual void  PaintPave(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
+                          Int_t bordersize=4 ,Option_t *option="br");
+  virtual void  PaintPaveArc(Double_t x1, Double_t y1,Double_t x2 ,Double_t y2,
+                             Int_t bordersize=4 ,Option_t *option="br");
+  virtual void  Print(Option_t *option="") const;
+  virtual void  SavePrimitive(std::ostream &out, Option_t *option = "");
+  virtual void  SetBorderSize(Int_t bordersize=4);
+  virtual void  SetCornerRadius(Double_t rad = 0.2);
+  virtual void  SetName(const char *name="");
+  virtual void  SetOption(Option_t *option="br");
+  virtual void  SetShadowColor(Int_t color);
+  virtual void  SetX1NDC(Double_t x1);
+  virtual void  SetX2NDC(Double_t x2);
+  virtual void  SetY1NDC(Double_t y1);
+  virtual void  SetY2NDC(Double_t y2);
+  virtual void  SetX1(Double_t x1);
+  virtual void  SetX2(Double_t x2);
+  virtual void  SetY1(Double_t y1);
+  virtual void  SetY2(Double_t y2);
+};


### PR DESCRIPTION
Hi @odakahirokazu 

Here's a proposal of changes that make color palette pave movable.

A color palette pave of the current pad can be accessed via:
```
palette = Root::gPad.get_palette()
```

See `example/color_palette.rb` for an example.

Looking forward to your feedback.