### PR TITLE
support variables passed by reference in `TGraph::GetPoint`

### DIFF
--- a/ruby/root_cast.i
+++ b/ruby/root_cast.i
@@ -52,3 +52,5 @@
 %template(castIntoTSpline3) castInto<TSpline3>;
 %template(castIntoTSpline5) castInto<TSpline5>;
 %template(castIntoTPaletteAxis) castInto<TPaletteAxis>;
+%template(castIntoTCanvas) castInto<TCanvas>;
+%template(castIntoTPad) castInto<TPad>;

--- a/ruby/root_graph.i
+++ b/ruby/root_graph.i
@@ -2,6 +2,8 @@
 /* Graph classes                                                          */
 /**************************************************************************/
 
+%include "typemaps.i"
+
 class TGraph : public TNamed, public TAttLine, public TAttFill, public TAttMarker {
 public:
   TGraph();
@@ -73,7 +75,9 @@ public:
   Double_t              GetMinimum()  const {return fMinimum;}
   TAxis                *GetXaxis() const ;
   TAxis                *GetYaxis() const ;
-  virtual Int_t         GetPoint(Int_t i, Double_t &x, Double_t &y) const;
+  virtual Int_t         GetPoint(Int_t i, Double_t &OUTPUT, Double_t &OUTPUT) const;
+  virtual Double_t      GetPointX(Int_t i) const;
+  virtual Double_t      GetPointY(Int_t i) const;
 
   virtual void          InitExpo(Double_t xmin=0, Double_t xmax=0);
   virtual void          InitGaus(Double_t xmin=0, Double_t xmax=0);


### PR DESCRIPTION
I had some trouble using `TGraph::GetPoint(Int_t i, Double_t &x, Double_t &y)`, where `x` and `y` are passed by reference. This PR proposes using `typemaps.i`, so that from Ruby one can do the following:

```
#!/usr/bin/env ruby
require 'RubyROOT'
graph = Root::TGraph.create([0,1,2],[0,2,4])
graph.GetN.times do |i|
  ret,x,y = graph.GetPoint(i) # only need to give one argument, since `x` and `y` are now outputs; `ret` is the return value of GetPoint
  puts [ x==graph.GetPointX(i), y==graph.GetPointY(i) ].join " " #=> true true
end
```

I'm not sure if this is the best solution, but it seems to work. Is there a better way to call `TGraph::GetPoint` from Ruby? Note there are several methods in ROOT where arguments are passed by reference, so it would be nice to have a clean way of using them from Ruby, and perhaps provide an example.

This PR also includes the following changes:
- add `TGraph::GetPointX` and `TGraph::GetPointY`
- add casts for `TPad` and `TCanvas`

Also, thanks for all the hard work on this project, I've been enjoying testing it