### PR TITLE
wrap TMultiGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Currently, this Ruby wapper offers the following ROOT classes:
 TApplication, TArrow, TAttAxis, TAttBBox2D, TAttFill, TAttLine,
 TAttMarker, TAttPad, TAttText, TAxis, TBox, TBranch, TCanvas,
 TChain, TCollection, TColor, TDirectory, TDirectoryFile, TEllipse,
-TF1, TFile, TFormula, TGraph, TGraphAsymmErrors, TGraphErrors,
+TF1, TFile, TFormula, TGraph, TGraphAsymmErrors, TGraphErrors, TMultiGraph
 TH1, TH1C, TH1D, TH1F, TH1I, TH1S, TH2, TH2C, TH2D, TH2F, TH2I,
 TH2S, TH3, TH3C, TH3D, TH3F, TH3I, TH3S, TKey, TLatex, TLeaf,
 TLegend, TLine, TList, TLorentzRotation, TLorentzVector, TMap,

--- a/examples/multi_graphs2.rb
+++ b/examples/multi_graphs2.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+require 'RubyROOT'
+include RootApp
+
+def make_data(seed, sigma, xs)
+  r = Root::TRandom3.new(seed)
+  xs.map{|x| r.Gaus(Math.sin(x), sigma) }
+end
+
+### data definition
+xs = (0..100).map{|i| 0.1*i }
+ys1 = make_data(1, 0.05, xs)
+ys2 = make_data(2, 0.2, xs)
+
+### make a graph and draw it
+curve = Root::TF1.new("func", "sin(x)", -1.0, 11.0)
+graph1 = Root::TGraph.create(xs, ys1)
+graph2 = Root::TGraph.create(xs, ys2)
+
+graph1.SetMarkerStyle 2
+graph2.SetMarkerStyle 4
+graph1.SetMarkerColor Root::KBlue
+graph2.SetMarkerColor Root::KGreen+1
+
+### add graph1 and graph2 to a TMultiGraph
+multi = Root::TMultiGraph.create
+[graph1,graph2].each{ |graph| multi.Add graph }
+
+mg = Root::MultiGraph.new
+mg.add(curve, '', 'Function', [-1.5, 1.5])
+mg.add(multi, 'AP', 'Graphs 1 and 2', [-1.5, 1.5])
+
+c1 = mg.draw('c1', 800, 200)
+mg.setXRange(-1.0, 11.0, 'x')
+
+c1.Update
+run_app

--- a/ruby/RubyROOT.rb
+++ b/ruby/RubyROOT.rb
@@ -465,6 +465,16 @@ module Root
     end
   end
 
+  class TMultiGraph
+    def self.create(name=nil, title=nil)
+      if(name and title)
+        TMultiGraph.new(name,title)
+      else
+        TMultiGraph.new()
+      end
+    end
+  end
+
   class TStyle
     def set_my_style()
       SetOptStat(0)

--- a/ruby/root.i
+++ b/ruby/root.i
@@ -30,6 +30,7 @@
 #include <TGraph.h>
 #include <TGraphErrors.h>
 #include <TGraphAsymmErrors.h>
+#include <TMultiGraph.h>
 #include <TFormula.h>
 #include <TF1.h>
 #include <TFile.h>

--- a/ruby/root_cast.i
+++ b/ruby/root_cast.i
@@ -43,6 +43,7 @@
 %template(castIntoTGraph) castInto<TGraph>;
 %template(castIntoTGraphErrors) castInto<TGraphErrors>;
 %template(castIntoTGraphAsymmErrors) castInto<TGraphAsymmErrors>;
+%template(castIntoTMultiGraph) castInto<TMultiGraph>;
 %template(castIntoTDirectory) castInto<TDirectory>;
 %template(castIntoTDirectoryFile) castInto<TDirectoryFile>;
 %template(castIntoTFile) castInto<TFile>;

--- a/ruby/root_graph.i
+++ b/ruby/root_graph.i
@@ -203,3 +203,45 @@ public:
   virtual void    SetPointEYlow(Int_t i, Double_t eyl);
   virtual void    SetPointEYhigh(Int_t i, Double_t eyh);
 };
+
+
+class TMultiGraph : public TNamed {
+public:
+  TMultiGraph();
+  TMultiGraph(const char *name, const char *title);
+  virtual ~TMultiGraph();
+
+  virtual void      Add(TGraph *graph, Option_t *chopt="");
+  virtual void      Add(TMultiGraph *multigraph, Option_t *chopt="");
+  virtual void      Browse(TBrowser *b);
+  virtual Int_t     DistancetoPrimitive(Int_t px, Int_t py);
+  virtual void      Draw(Option_t *chopt="");
+  virtual TFitResultPtr Fit(const char *formula ,Option_t *option="" ,Option_t *goption="", Axis_t xmin=0, Axis_t xmax=0);
+  virtual TFitResultPtr Fit(TF1 *f1 ,Option_t *option="" ,Option_t *goption="", Axis_t rxmin=0, Axis_t rxmax=0);
+  virtual void      FitPanel(); // *MENU*
+  virtual Option_t *GetGraphDrawOption(const TGraph *gr) const;
+  virtual void      LeastSquareLinearFit(Int_t ndata, Double_t &a0, Double_t &a1, Int_t &ifail, Double_t xmin, Double_t xmax);
+  virtual void      LeastSquareFit(Int_t m, Double_t *a, Double_t xmin, Double_t xmax);
+  virtual void      InitPolynom(Double_t xmin, Double_t xmax);
+  virtual void      InitExpo(Double_t xmin, Double_t xmax);
+  virtual void      InitGaus(Double_t xmin, Double_t xmax);
+  virtual Int_t     IsInside(Double_t x, Double_t y) const;
+  TH1F             *GetHistogram();
+  TF1              *GetFunction(const char *name) const;
+  TList            *GetListOfGraphs() const { return fGraphs; }
+  /* TIter             begin() const; */
+  /* TIter             end() const { return TIter::End(); } */
+  TList            *GetListOfFunctions();  // non const method (create list if empty)
+  const TList      *GetListOfFunctions() const { return fFunctions; }
+  TAxis            *GetXaxis();
+  TAxis            *GetYaxis();
+  virtual void      Paint(Option_t *chopt="");
+  void              PaintPads(Option_t *chopt="");
+  void              PaintPolyLine3D(Option_t *chopt="");
+  void              PaintReverse(Option_t *chopt="");
+  virtual void      Print(Option_t *chopt="") const;
+  virtual void      RecursiveRemove(TObject *obj);
+  virtual void      SavePrimitive(std::ostream &out, Option_t *option = "");
+  virtual void      SetMaximum(Double_t maximum=-1111);
+  virtual void      SetMinimum(Double_t minimum=-1111);
+};


### PR DESCRIPTION
add wrapping for `TMultiGraph`
- includes new example `examples/multi_graphs2.rb`, which is copied from `examples/multi_graph.rb`, but adds `graph1` and `graph2` to a `TMultiGraph`

**currently marked as a draft PR until more testing can be done**